### PR TITLE
Use a single row item for all elements

### DIFF
--- a/app/src/main/java/dev/msfjarvis/todo/MainActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/todo/MainActivity.kt
@@ -23,7 +23,6 @@ import androidx.ui.tooling.preview.Preview
 import dev.msfjarvis.todo.data.TodoItem
 import dev.msfjarvis.todo.ui.TodoRowItem
 import dev.msfjarvis.todo.ui.TodoTheme
-import dev.msfjarvis.todo.ui.WireGuardItem
 
 class MainActivity : AppCompatActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -56,12 +55,7 @@ fun TodoApp() {
     },
     bodyContent = {
       LazyColumnFor(items = items, modifier = Modifier.padding(horizontal = 16.dp)) { todoItem ->
-        val isOdd = items.indexOf(todoItem) % 2 == 1
-        if (isOdd) {
-          WireGuardItem(item = todoItem)
-        } else {
-          TodoRowItem(item = todoItem)
-        }
+        TodoRowItem(item = todoItem)
       }
     },
   )


### PR DESCRIPTION
The WireGuardItem class was created to compare an existing UI elements from standard view-based apps into a Compose alternative and doesn't really belong here
