### PR TITLE
Switch to createComposeRule

### DIFF
--- a/app/src/androidTest/java/dev/msfjarvis/todo/MainActivityTest.kt
+++ b/app/src/androidTest/java/dev/msfjarvis/todo/MainActivityTest.kt
@@ -1,7 +1,7 @@
 package dev.msfjarvis.todo
 
-import androidx.ui.test.android.createAndroidComposeRule
 import androidx.ui.test.assertIsDisplayed
+import androidx.ui.test.createComposeRule
 import androidx.ui.test.hasTestTag
 import androidx.ui.test.onNode
 import androidx.ui.test.onNodeWithText
@@ -13,7 +13,7 @@ import org.junit.Test
 class MainActivityTest {
 
   @get:Rule
-  val composeTestRule = createAndroidComposeRule<MainActivity>(disableTransitions = true)
+  val composeTestRule = createComposeRule()
 
   @Test
   fun test_item_addition() {

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <!--
+        If you don't need the activityTestRule, then you can switch to createComposeRule and add
+        an empty activity here for the test harness to launch. Not having this activity is what
+        broke my tests when I first started writing them with createComposeRule. Future me will thank
+        past me for writing this note here.
+        -->
+        <activity android:name="androidx.activity.ComponentActivity" />
+    </application>
+</manifest>


### PR DESCRIPTION
We're not using the `activityTestRule` being provided by `createAndroidComposeRule` so let's not have it.
