### PR TITLE
Dependency updates

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,6 +4,9 @@ name: Check pull request
 jobs:
   test-pr:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        api-level: [23, 29]
     steps:
 
     - name: Check if relevant files have changed
@@ -37,7 +40,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       uses: reactivecircus/android-emulator-runner@v2.11.0
       with:
-        api-level: 29
+        api-level: ${{ matrix.api-level }}
         target: default
         script: ./gradlew :app:connectedDebugAndroidTest
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,9 +15,7 @@ android {
         }
     }
 
-    buildFeatures {
-        compose true
-    }
+    buildFeatures.compose = true
 
     composeOptions {
         kotlinCompilerVersion "${kotlin_version}"
@@ -49,7 +47,5 @@ dependencies {
     implementation "androidx.ui:ui-tooling:$compose_version"
     implementation 'com.google.android.material:material:1.3.0-alpha02'
     testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     androidTestImplementation "androidx.ui:ui-test:$compose_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,8 @@ android {
         }
     }
 
+    compileOptions.coreLibraryDesugaringEnabled = true
+
     buildFeatures.compose = true
 
     composeOptions {
@@ -48,4 +50,5 @@ dependencies {
     implementation 'com.google.android.material:material:1.3.0-alpha02'
     testImplementation 'junit:junit:4.13'
     androidTestImplementation "androidx.ui:ui-test:$compose_version"
+    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerVersion '1.4.0'
+        kotlinCompilerVersion "${kotlin_version}"
         kotlinCompilerExtensionVersion "${compose_version}"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         compose_version = '1.0.0-alpha02'
-        kotlin_version = '1.4.0'
+        kotlin_version = '1.4.10'
         room_version = '2.3.0-alpha02'
     }
     repositories {
@@ -10,7 +10,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:4.2.0-alpha09"
+        classpath "com.android.tools.build:gradle:4.2.0-alpha10"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -34,7 +34,6 @@ subprojects {
     }
     android {
         compileSdkVersion 30
-        buildToolsVersion "30.0.2"
 
         defaultConfig {
             minSdkVersion 23

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -3,15 +3,8 @@ plugins {
     id 'kotlin-kapt'
 }
 
-android {
-    compileOptions {
-        coreLibraryDesugaringEnabled true
-    }
-}
-
 dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     api "androidx.room:room-runtime:$room_version"
     api "androidx.room:room-ktx:$room_version"
-    coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -4,11 +4,6 @@ plugins {
 }
 
 android {
-
-    defaultConfig {
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
-
     compileOptions {
         coreLibraryDesugaringEnabled true
     }
@@ -18,8 +13,5 @@ dependencies {
     kapt "androidx.room:room-compiler:$room_version"
     api "androidx.room:room-runtime:$room_version"
     api "androidx.room:room-ktx:$room_version"
-    testImplementation 'junit:junit:4.13'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     coreLibraryDesugaring "com.android.tools:desugar_jdk_libs:1.0.10"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+# Enabling filesystem watching
+org.gradle.vfs.watch=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates to:
- Gradle 6.7 RC1
- Kotlin 1.4.10
- AGP 4.2a10

Also drops unused testing dependencies, fixes library desugaring to actually work, and ensures its never broken again by making tests run on API 23 alongside API 29.
